### PR TITLE
Asynchronous service design

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 
   include:
     - rust: stable
-    - rust: 1.34.0
+    - rust: 1.40.0
     - rust: nightly
 
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
 [workspace]
-members = ["libsignal-service"]
+members = [
+    "libsignal-service",
+    "libsignal-service-actix",
+]

--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "libsignal-service-actix"
+version = "0.1.0"
+authors = ["Ruben De Smet <ruben.de.smet@rubdos.be>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libsignal-service = { path = "../libsignal-service" }
+libsignal-protocol = { git = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs" }
+
+awc = { version = "2.0.0-alpha.2", features=["rustls"] }
+actix-rt = "1.1"
+rustls = "0.17"
+
+failure = "0.1.5"
+thiserror = "1.0"
+async-trait = "0.1.35"

--- a/libsignal-service-actix/src/lib.rs
+++ b/libsignal-service-actix/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod push_service;

--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -1,0 +1,24 @@
+use libsignal_service::{configuration::*, push_service::*};
+
+pub struct AwcPushService {
+    client: awc::Client,
+}
+
+#[async_trait::async_trait(?Send)]
+impl PushService for AwcPushService {
+    async fn get(&mut self, _path: &str) -> Result<(), ServiceError> { Ok(()) }
+}
+
+impl AwcPushService {
+    pub fn new<T: CredentialsProvider>(
+        _cfg: ServiceConfiguration,
+        _credentials: T,
+        user_agent: &str,
+    ) -> Self {
+        Self {
+            client: awc::ClientBuilder::new()
+                .header("X-Signal-Agent", user_agent)
+                .finish(),
+        }
+    }
+}

--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -7,8 +7,12 @@ license = "GPLv3"
 readme = "../README.md"
 
 [dependencies]
-libsignal-protocol = { git = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs", rev = "39077a7" }
+libsignal-protocol = { git = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs" }
 failure = "0.1.5"
+async-trait = "0.1.35"
+url = "2.1.1"
+thiserror = "1.0"
 
 [dev-dependencies]
 structopt = "0.2.17"
+tokio = { version = "0.2", features=["macros"] }

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -1,63 +1,17 @@
-use crate::{TrustStore, USER_AGENT};
+use crate::push_service::{PushService, SmsVerificationCodeResponse};
+
 use failure::Error;
 
-pub struct AccountManager;
-
-impl AccountManager {
-    pub fn builder() -> AccountManagerBuilder {
-        AccountManagerBuilder::default()
-    }
-
-    pub fn request_sms_verification_code(&mut self) -> Result<(), Error> {
-        unimplemented!()
-    }
+pub struct AccountManager<Service> {
+    service: Service,
 }
 
-pub struct AccountManagerBuilder {
-    username: Option<String>,
-    password: Option<String>,
-    user_agent: String,
-    server: Option<String>,
-    trust_store: Option<TrustStore>,
-}
+impl<Service: PushService> AccountManager<Service> {
+    pub fn new(service: Service) -> Self { Self { service } }
 
-impl AccountManagerBuilder {
-    pub fn credentials<U: Into<String>, P: Into<String>>(
+    pub async fn request_sms_verification_code(
         &mut self,
-        username: U,
-        password: P,
-    ) -> &mut Self {
-        self.username = Some(username.into());
-        self.password = Some(password.into());
-        self
-    }
-
-    pub fn server<S: Into<String>>(&mut self, server: S) -> &mut Self {
-        self.server = Some(server.into());
-        self
-    }
-
-    pub fn trust_store(&mut self, trust_store: TrustStore) -> &mut Self {
-        self.trust_store = Some(trust_store);
-        self
-    }
-
-    pub fn user_agent<U: Into<String>>(&mut self, user_agent: U) -> &mut Self {
-        self.user_agent = user_agent.into();
-        self
-    }
-
-    pub fn build(&mut self) -> AccountManager { AccountManager }
-}
-
-impl Default for AccountManagerBuilder {
-    fn default() -> AccountManagerBuilder {
-        AccountManagerBuilder {
-            username: None,
-            password: None,
-            user_agent: String::from(USER_AGENT),
-            server: None,
-            trust_store: None,
-        }
+    ) -> Result<SmsVerificationCodeResponse, Error> {
+        Ok(self.service.request_sms_verification_code().await?)
     }
 }

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -1,0 +1,28 @@
+#[derive(Clone, Default)]
+pub struct ServiceConfiguration {
+    pub service_urls: Vec<String>,
+    pub cdn_urls: Vec<String>,
+    pub contact_discovery_url: Vec<String>,
+}
+
+pub trait CredentialsProvider {
+    fn get_uuid(&self) -> String;
+
+    fn get_e164(&self) -> String;
+
+    fn get_password(&self) -> String;
+}
+
+pub struct StaticCredentialsProvider {
+    pub uuid: String,
+    pub e164: String,
+    pub password: String,
+}
+
+impl CredentialsProvider for StaticCredentialsProvider {
+    fn get_uuid(&self) -> String { self.uuid.clone() }
+
+    fn get_e164(&self) -> String { self.e164.clone() }
+
+    fn get_password(&self) -> String { self.password.clone() }
+}

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -1,6 +1,9 @@
 mod account_manager;
+pub mod configuration;
+pub mod push_service;
+pub mod receiver;
 
-pub use crate::account_manager::{AccountManager, AccountManagerBuilder};
+pub use crate::account_manager::AccountManager;
 
 pub const USER_AGENT: &'static str =
     concat!(env!("CARGO_PKG_NAME"), "-rs-", env!("CARGO_PKG_VERSION"));

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1,0 +1,83 @@
+use crate::configuration::{CredentialsProvider, ServiceConfiguration};
+
+pub const CREATE_ACCOUNT_SMS_PATH: &str = "/v1/accounts/sms/code/%s?client=%s";
+pub const CREATE_ACCOUNT_VOICE_PATH: &str = "/v1/accounts/voice/code/%s";
+pub const VERIFY_ACCOUNT_CODE_PATH: &str = "/v1/accounts/code/%s";
+pub const REGISTER_GCM_PATH: &str = "/v1/accounts/gcm/";
+pub const TURN_SERVER_INFO: &str = "/v1/accounts/turn";
+pub const SET_ACCOUNT_ATTRIBUTES: &str = "/v1/accounts/attributes/";
+pub const PIN_PATH: &str = "/v1/accounts/pin/";
+pub const REQUEST_PUSH_CHALLENGE: &str = "/v1/accounts/fcm/preauth/%s/%s";
+pub const WHO_AM_I: &str = "/v1/accounts/whoami";
+
+pub const PREKEY_METADATA_PATH: &str = "/v2/keys/";
+pub const PREKEY_PATH: &str = "/v2/keys/%s";
+pub const PREKEY_DEVICE_PATH: &str = "/v2/keys/%s/%s";
+pub const SIGNED_PREKEY_PATH: &str = "/v2/keys/signed";
+
+pub const PROVISIONING_CODE_PATH: &str = "/v1/devices/provisioning/code";
+pub const PROVISIONING_MESSAGE_PATH: &str = "/v1/provisioning/%s";
+pub const DEVICE_PATH: &str = "/v1/devices/%s";
+
+pub const DIRECTORY_TOKENS_PATH: &str = "/v1/directory/tokens";
+pub const DIRECTORY_VERIFY_PATH: &str = "/v1/directory/%s";
+pub const DIRECTORY_AUTH_PATH: &str = "/v1/directory/auth";
+pub const DIRECTORY_FEEDBACK_PATH: &str = "/v1/directory/feedback-v3/%s";
+pub const MESSAGE_PATH: &str = "/v1/messages/%s";
+pub const SENDER_ACK_MESSAGE_PATH: &str = "/v1/messages/%s/%d";
+pub const UUID_ACK_MESSAGE_PATH: &str = "/v1/messages/uuid/%s";
+pub const ATTACHMENT_PATH: &str = "/v2/attachments/form/upload";
+
+pub const PROFILE_PATH: &str = "/v1/profile/%s";
+
+pub const SENDER_CERTIFICATE_LEGACY_PATH: &str = "/v1/certificate/delivery";
+pub const SENDER_CERTIFICATE_PATH: &str =
+    "/v1/certificate/delivery?includeUuid=true";
+
+pub const ATTACHMENT_DOWNLOAD_PATH: &str = "attachments/%d";
+pub const ATTACHMENT_UPLOAD_PATH: &str = "attachments/";
+
+pub const STICKER_MANIFEST_PATH: &str = "stickers/%s/manifest.proto";
+pub const STICKER_PATH: &str = "stickers/%s/full/%d";
+
+pub enum SmsVerificationCodeResponse {
+    CaptchaRequired,
+    SmsSent,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ServiceError {}
+
+#[async_trait::async_trait(?Send)]
+pub trait PushService {
+    async fn get(&mut self, path: &str) -> Result<(), ServiceError>;
+
+    async fn request_sms_verification_code(
+        &mut self,
+    ) -> Result<SmsVerificationCodeResponse, ServiceError> {
+        self.get(CREATE_ACCOUNT_SMS_PATH).await?;
+        Ok(SmsVerificationCodeResponse::SmsSent)
+    }
+}
+
+/// PushService that panics on every request, mainly for example code.
+pub struct PanicingPushService;
+
+impl PanicingPushService {
+    /// A PushService implementation typically takes a ServiceConfiguration,
+    /// credentials and a user agent.
+    pub fn new<T: CredentialsProvider>(
+        _cfg: ServiceConfiguration,
+        _credentials: T,
+        _user_agent: &str,
+    ) -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl PushService for PanicingPushService {
+    async fn get(&mut self, path: &str) -> Result<(), ServiceError> {
+        unimplemented!()
+    }
+}

--- a/libsignal-service/src/receiver.rs
+++ b/libsignal-service/src/receiver.rs
@@ -1,0 +1,15 @@
+use crate::{configuration::*, push_service::PushService};
+
+use libsignal_protocol::StoreContext;
+
+/// Equivalent of Java's `SignalServiceMessageReceiver`.
+pub struct MessageReceiver<Service> {
+    service: Service,
+    context: StoreContext,
+}
+
+impl<Service: PushService> MessageReceiver<Service> {
+    pub fn new(service: Service, context: StoreContext) -> Self {
+        MessageReceiver { service, context }
+    }
+}


### PR DESCRIPTION
Hi!

as I already said [in a comment](https://github.com/Michael-F-Bryan/libsignal-protocol-rs/issues/40#issuecomment-636543016), I'm rebuilding a Signal app for SailfishOS, called [Whisperfish](https://gitlab.com/rubdos/whisperfish/).

This version makes use of Qt and Actix, which [share their event loop](https://www.rubdos.be/corona/qt/rust/tokio/actix/2020/05/23/actix-qt.html).  If I'm going to contribute to this service crate (which I intend to!), the interfaces should be async-compatible.

This is a first experiment to define the AccountManager as a trait (since the runtime is an unknown, also in a synchronous context), and makes the `request_sms_verification_code` method asynchronous (it yields the `Future` when the request has been sent). To make `async` methods in a trait, I've opted to use the [`async-trait` crate](https://crates.io/crates/async-trait), because currently `async` `trait`s are not implemented (and are [hard to implement](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/), although not impossible).

Note that the intention here is to keep the base `-service` crate *runtime agnostic*. As a next step, I would provide a Tokio/Actix based implementation of the `trait`s defined in the `-service` crate.

What do you think?