### PR TITLE
Add the two group flags from textsecure

### DIFF
--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -11,4 +11,10 @@ pub use crate::account_manager::AccountManager;
 pub const USER_AGENT: &'static str =
     concat!(env!("CARGO_PKG_NAME"), "-rs-", env!("CARGO_PKG_VERSION"));
 
+/// GROUP_UPDATE_FLAG signals that this message updates the group membership or name.
+pub const GROUP_UPDATE_FLAG: u32 = 1;
+
+/// GROUP_LEAVE_FLAG signals that this message is a group leave message.
+pub const GROUP_LEAVE_FLAG: u32 = 2;
+
 pub struct TrustStore;

--- a/libsignal-service/src/models.rs
+++ b/libsignal-service/src/models.rs
@@ -28,7 +28,7 @@ pub struct Message {
     pub source: String,
     pub message: String,
     pub attachments: Vec<Attachment<u8>>,
-    pub group: Group,
+    pub group: Option<Group>,
     pub timestamp: i64,
     pub flags: i32,
 }


### PR DESCRIPTION
And they are u32 there, but Whisperfish uses i32
so let's align with that.
