### PR TITLE
Finish registering / linking device

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     packages:
       - protobuf-compiler
 
-script: 
+script:
   - cargo build --all --verbose
   - cargo test --all --verbose
   - cargo doc --all --verbose
@@ -25,7 +25,7 @@ matrix:
 
   include:
     - rust: stable
-    - rust: 1.42.0
+    - rust: 1.47.0
     - rust: nightly
 
     - rust: stable
@@ -40,7 +40,7 @@ matrix:
 deploy:
   provider: pages
   skip_cleanup: true
-  github_token: $GITHUB_TOKEN 
+  github_token: $GITHUB_TOKEN
   keep_history: true
   local_dir: public
   on:

--- a/libsignal-service-actix/src/provisioning.rs
+++ b/libsignal-service-actix/src/provisioning.rs
@@ -1,49 +1,53 @@
-use failure::Error;
 use futures::{channel::mpsc::Sender, pin_mut, SinkExt, StreamExt};
-use serde::Serialize;
 use url::Url;
 
 use crate::push_service::AwcPushService;
 use libsignal_protocol::{
-    generate_registration_id, keys::PrivateKey, keys::PublicKey, Context,
+    generate_registration_id,
+    keys::{PrivateKey, PublicKey},
+    Context,
 };
 use libsignal_service::{
-    configuration::ServiceConfiguration, configuration::SignalServers,
-    messagepipe::Credentials, prelude::PushService,
-    provisioning::ProvisioningError, provisioning::ProvisioningPipe,
-    provisioning::ProvisioningStep, push_service::ConfirmCodeMessage,
-    push_service::DeviceId, push_service::PROVISIONING_WEBSOCKET_PATH,
+    configuration::ServiceConfiguration,
+    messagepipe::Credentials,
+    prelude::PushService,
+    provisioning::{ProvisioningError, ProvisioningPipe, ProvisioningStep},
+    push_service::{ConfirmDeviceMessage, DeviceId},
     USER_AGENT,
 };
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub enum SecondaryDeviceProvisioning {
     Url(Url),
     NewDeviceRegistration {
+        phone_number: String,
         device_id: DeviceId,
         uuid: String,
-        #[serde(skip)]
-        public_key: PublicKey,
-        #[serde(skip)]
         private_key: PrivateKey,
+        public_key: PublicKey,
+        profile_key: Vec<u8>,
     },
 }
 
 pub async fn provision_secondary_device(
     ctx: &Context,
-    signaling_key: [u8; 52],
-    password: [u8; 16],
+    service_configuration: &ServiceConfiguration,
+    signaling_key: &[u8; 52],
+    password: &str,
     device_name: &str,
     mut tx: Sender<SecondaryDeviceProvisioning>,
-) -> Result<(), Error> {
-    let service_configuration: ServiceConfiguration =
-        SignalServers::Production.into();
+) -> Result<(), ProvisioningError> {
+    assert_eq!(
+        password.len(),
+        24,
+        "the password needs to be a 24 characters ASCII string"
+    );
 
     let mut push_service =
         AwcPushService::new(service_configuration.clone(), None, USER_AGENT);
 
     let (ws, stream) =
-        push_service.ws(PROVISIONING_WEBSOCKET_PATH, None).await?;
+        push_service.ws("/v1/websocket/provisioning/", None).await?;
 
     let registration_id = generate_registration_id(&ctx, 0)?;
 
@@ -53,20 +57,11 @@ pub async fn provision_secondary_device(
     while let Some(step) = provision_stream.next().await {
         match step {
             Ok(ProvisioningStep::Url(url)) => {
-                tx.send(SecondaryDeviceProvisioning::Url(url)).await?;
+                tx.send(SecondaryDeviceProvisioning::Url(url))
+                    .await
+                    .expect("failed to send provisioning Url in channel");
             }
             Ok(ProvisioningStep::Message(message)) => {
-                let credentials = Credentials {
-                    e164: message.number.ok_or(
-                        ProvisioningError::InvalidData {
-                            reason: "missing number".into(),
-                        },
-                    )?,
-                    uuid: None,
-                    password: Some(base64::encode(password)),
-                    signaling_key,
-                };
-
                 let uuid =
                     message.uuid.ok_or(ProvisioningError::InvalidData {
                         reason: "missing client UUID".into(),
@@ -80,6 +75,7 @@ pub async fn provision_secondary_device(
                         },
                     )?,
                 )?;
+
                 let private_key = PrivateKey::decode_point(
                     &ctx,
                     &message.identity_key_private.ok_or(
@@ -89,9 +85,27 @@ pub async fn provision_secondary_device(
                     )?,
                 )?;
 
+                let profile_key = message.profile_key.ok_or(
+                    ProvisioningError::InvalidData {
+                        reason: "missing profile key".into(),
+                    },
+                )?;
+
+                let phone_number =
+                    message.number.ok_or(ProvisioningError::InvalidData {
+                        reason: "missing phone number".into(),
+                    })?;
+
+                // we need to authenticate with the phone number
+                // to confirm the new device
                 let mut push_service = AwcPushService::new(
                     service_configuration.clone(),
-                    Some(credentials),
+                    Some(Credentials {
+                        e164: phone_number.clone(),
+                        uuid: None,
+                        password: Some(password.to_string()),
+                        signaling_key: Some(*signaling_key),
+                    }),
                     USER_AGENT,
                 );
 
@@ -105,9 +119,9 @@ pub async fn provision_secondary_device(
                             })?
                             .parse()
                             .unwrap(),
-                        &ConfirmCodeMessage {
+                        ConfirmDeviceMessage {
                             signaling_key: signaling_key.to_vec(),
-                            supports_sms: true,
+                            supports_sms: false,
                             fetches_messages: true,
                             registration_id,
                             name: device_name.to_string(),
@@ -116,12 +130,15 @@ pub async fn provision_secondary_device(
                     .await?;
 
                 tx.send(SecondaryDeviceProvisioning::NewDeviceRegistration {
+                    phone_number,
                     device_id,
                     uuid,
-                    public_key,
                     private_key,
+                    public_key,
+                    profile_key,
                 })
-                .await?;
+                .await
+                .expect("failed to send provisioning message in rx channel");
             }
             Err(e) => return Err(e.into()),
         }

--- a/libsignal-service-actix/src/websocket.rs
+++ b/libsignal-service-actix/src/websocket.rs
@@ -1,6 +1,11 @@
 use actix::Arbiter;
 
-use awc::{error::WsProtocolError, ws, ws::Frame};
+use awc::{
+    error::{WsClientError, WsProtocolError},
+    http::StatusCode,
+    ws,
+    ws::Frame,
+};
 use bytes::Bytes;
 use futures::{channel::mpsc::*, prelude::*};
 use url::Url;
@@ -23,7 +28,19 @@ pub enum AwcWebSocketError {
 
 impl From<AwcWebSocketError> for ServiceError {
     fn from(e: AwcWebSocketError) -> ServiceError {
-        todo!("error conversion {:?}", e)
+        match e {
+            AwcWebSocketError::ConnectionError(e) => match e {
+                WsClientError::InvalidResponseStatus(s) => match s {
+                    StatusCode::FORBIDDEN => ServiceError::Unauthorized,
+                    s => ServiceError::WsError {
+                        reason: format!("HTTP status {}", s),
+                    },
+                },
+                e => ServiceError::WsError {
+                    reason: e.to_string(),
+                },
+            },
+        }
     }
 }
 

--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.8"
 sha2 = "0.9.0"
 hmac = "0.9.0"
 aes = "0.5.0"
+aes-gcm = "0.8.0"
 block-modes = "0.6.0"
 
 [dev-dependencies]

--- a/libsignal-service/examples/registering.rs
+++ b/libsignal-service/examples/registering.rs
@@ -44,9 +44,9 @@ async fn main() -> Result<(), Error> {
     .unwrap();
     let credentials = Credentials {
         uuid: None,
-        e164: args.username,
+        e164: args.username.clone(),
         password: Some(password),
-        signaling_key,
+        signaling_key: Some(signaling_key),
     };
 
     let service = PanicingPushService::new(
@@ -56,7 +56,9 @@ async fn main() -> Result<(), Error> {
     );
 
     let mut account_manager = AccountManager::new(service);
-    account_manager.request_sms_verification_code().await?;
+    account_manager
+        .request_sms_verification_code(&args.username)
+        .await?;
 
     Ok(())
 }

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -1,5 +1,5 @@
 use crate::push_service::{
-    ConfirmCodeMessage, DeviceId, PushService, SmsVerificationCodeResponse,
+    ConfirmDeviceMessage, DeviceId, PushService, SmsVerificationCodeResponse,
     VoiceVerificationCodeResponse,
 };
 
@@ -16,24 +16,32 @@ impl<Service: PushService> AccountManager<Service> {
 
     pub async fn request_sms_verification_code(
         &mut self,
+        phone_number: &str,
     ) -> Result<SmsVerificationCodeResponse, Error> {
-        Ok(self.service.request_sms_verification_code().await?)
+        Ok(self
+            .service
+            .request_sms_verification_code(phone_number)
+            .await?)
     }
 
     pub async fn request_voice_verification_code(
         &mut self,
+        phone_number: &str,
     ) -> Result<VoiceVerificationCodeResponse, Error> {
-        Ok(self.service.request_voice_verification_code().await?)
+        Ok(self
+            .service
+            .request_voice_verification_code(phone_number)
+            .await?)
     }
 
     pub async fn confirm_device(
         &mut self,
         confirmation_code: u32,
-        confirm_code_message: &ConfirmCodeMessage,
+        confirm_device_message: ConfirmDeviceMessage,
     ) -> Result<DeviceId, Error> {
         Ok(self
             .service
-            .confirm_device(confirmation_code, confirm_code_message)
+            .confirm_device(confirmation_code, confirm_device_message)
             .await?)
     }
 }

--- a/libsignal-service/src/envelope.rs
+++ b/libsignal-service/src/envelope.rs
@@ -3,7 +3,8 @@
 use prost::Message;
 
 use crate::{
-    push_service::ServiceError, utils::serde_optional_base64, ServiceAddress,
+    configuration::SignalingKey, push_service::ServiceError,
+    utils::serde_optional_base64, ServiceAddress,
 };
 
 pub use crate::proto::Envelope;
@@ -28,7 +29,7 @@ impl From<EnvelopeEntity> for Envelope {
 impl Envelope {
     pub fn decrypt(
         input: &[u8],
-        signaling_key: &[u8; CIPHER_KEY_SIZE + MAC_KEY_SIZE],
+        signaling_key: &SignalingKey,
         is_signaling_key_encrypted: bool,
     ) -> Result<Self, ServiceError> {
         if !is_signaling_key_encrypted {

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -8,11 +8,12 @@ pub mod content;
 pub mod envelope;
 pub mod messagepipe;
 pub mod models;
+pub mod pre_keys;
 mod proto;
 pub mod provisioning;
 pub mod push_service;
 pub mod receiver;
-mod utils;
+pub mod utils;
 
 pub use crate::account_manager::AccountManager;
 
@@ -50,7 +51,7 @@ pub mod prelude {
     pub use super::ServiceAddress;
     pub use crate::{
         cipher::ServiceCipher,
-        configuration::{Credentials, ServiceConfiguration, SignalServers},
+        configuration::{Credentials, ServiceConfiguration, SignalingKey},
         content::Content,
         envelope::Envelope,
         push_service::{PushService, ServiceError},

--- a/libsignal-service/src/messagepipe.rs
+++ b/libsignal-service/src/messagepipe.rs
@@ -18,7 +18,7 @@ pub use crate::{
         web_socket_message, Envelope, WebSocketMessage,
         WebSocketRequestMessage, WebSocketResponseMessage,
     },
-    push_service::ServiceError,
+    prelude::ServiceError,
 };
 
 pub enum WebSocketStreamItem {
@@ -229,7 +229,9 @@ impl<WS: WebSocketService> MessagePipe<WS> {
                     };
                     Some(Envelope::decrypt(
                         body,
-                        &self.credentials.signaling_key,
+                        &self.credentials.signaling_key.as_ref().expect(
+                            "signaling_key required to decrypt envelopes",
+                        ),
                         request.is_signal_key_encrypted(),
                     )?)
                 } else {

--- a/libsignal-service/src/pre_keys.rs
+++ b/libsignal-service/src/pre_keys.rs
@@ -1,0 +1,50 @@
+use crate::utils::{serde_base64, serde_public_key};
+use libsignal_protocol::keys::{PreKey, PublicKey, SessionSignedPreKey};
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreKeyEntity {
+    key_id: u32,
+    #[serde(serialize_with = "serde_public_key::serialize")]
+    public_key: PublicKey,
+}
+
+impl From<PreKey> for PreKeyEntity {
+    fn from(key: PreKey) -> PreKeyEntity {
+        PreKeyEntity {
+            key_id: key.id(),
+            public_key: key.key_pair().public(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignedPreKey {
+    key_id: u32,
+    #[serde(with = "serde_public_key")]
+    public_key: PublicKey,
+    #[serde(with = "serde_base64")]
+    signature: Vec<u8>,
+}
+
+impl From<SessionSignedPreKey> for SignedPreKey {
+    fn from(key: SessionSignedPreKey) -> SignedPreKey {
+        SignedPreKey {
+            key_id: key.id(),
+            public_key: key.key_pair().public(),
+            signature: key.signature().to_vec(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreKeyState {
+    pub pre_keys: Vec<PreKeyEntity>,
+    pub signed_pre_key: SignedPreKey,
+    #[serde(with = "serde_public_key")]
+    pub identity_key: PublicKey,
+}

--- a/libsignal-service/src/provisioning.rs
+++ b/libsignal-service/src/provisioning.rs
@@ -212,7 +212,8 @@ impl<WS: WebSocketService> ProvisioningPipe<WS> {
         match (msg.r#type(), msg.request, msg.response) {
             (Type::Request, Some(request), _) => {
                 match request {
-                    // step 1: we get a ProvisioningUUID that we need to build a registration link
+                    // step 1: we get a ProvisioningUUID that we need to build a
+                    // registration link
                     WebSocketRequestMessage {
                         id,
                         verb,
@@ -244,8 +245,10 @@ impl<WS: WebSocketService> ProvisioningPipe<WS> {
 
                         Ok(Some(ProvisioningStep::Url(provisioning_url)))
                     }
-                    // step 2: once the QR code is scanned by the (already validated) main device
-                    // we get a ProvisionMessage, that contains a bunch of useful things
+                    // step 2: once the QR code is scanned by the (already
+                    // validated) main device
+                    // we get a ProvisionMessage, that contains a bunch of
+                    // useful things
                     WebSocketRequestMessage {
                         id,
                         verb,
@@ -305,6 +308,8 @@ pub enum ProvisioningError {
     WsClosing { reason: String },
     #[error("Service error: {0}")]
     ServiceError(ServiceError),
+    #[error("libsignal-protocol error: {0}")]
+    ProtocolError(#[from] libsignal_protocol::Error),
 }
 
 impl From<failure::Error> for ProvisioningError {

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -4,16 +4,18 @@ use crate::{
     configuration::{Credentials, ServiceConfiguration},
     envelope::*,
     messagepipe::WebSocketService,
+    pre_keys::PreKeyState,
     proto::{attachment_pointer::AttachmentIdentifier, AttachmentPointer},
     utils::serde_base64,
 };
 
+use aes::block_cipher::generic_array::GenericArray;
+use aes_gcm::{aead::Aead, Aes256Gcm, NewAead};
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
 
-pub const CREATE_ACCOUNT_SMS_PATH: &str = "/v1/accounts/sms/code/%s?client=%s";
-pub const CREATE_ACCOUNT_VOICE_PATH: &str = "/v1/accounts/voice/code/%s";
-pub const VERIFY_ACCOUNT_CODE_PATH: &str = "/v1/accounts/code/%s";
+/**
+Since we can't use format!() with constants, the URLs here are just for reference purposes
 pub const REGISTER_GCM_PATH: &str = "/v1/accounts/gcm/";
 pub const TURN_SERVER_INFO: &str = "/v1/accounts/turn";
 pub const SET_ACCOUNT_ATTRIBUTES: &str = "/v1/accounts/attributes/";
@@ -21,38 +23,32 @@ pub const PIN_PATH: &str = "/v1/accounts/pin/";
 pub const REQUEST_PUSH_CHALLENGE: &str = "/v1/accounts/fcm/preauth/%s/%s";
 pub const WHO_AM_I: &str = "/v1/accounts/whoami";
 
-pub const PREKEY_METADATA_PATH: &str = "/v2/keys/";
 pub const PREKEY_PATH: &str = "/v2/keys/%s";
 pub const PREKEY_DEVICE_PATH: &str = "/v2/keys/%s/%s";
 pub const SIGNED_PREKEY_PATH: &str = "/v2/keys/signed";
 
 pub const PROVISIONING_CODE_PATH: &str = "/v1/devices/provisioning/code";
 pub const PROVISIONING_MESSAGE_PATH: &str = "/v1/provisioning/%s";
-pub const DEVICE_PATH: &str = "/v1/devices/";
-pub const PROVISIONING_WEBSOCKET_PATH: &str = "/v1/websocket/provisioning/";
 
 pub const DIRECTORY_TOKENS_PATH: &str = "/v1/directory/tokens";
 pub const DIRECTORY_VERIFY_PATH: &str = "/v1/directory/%s";
 pub const DIRECTORY_AUTH_PATH: &str = "/v1/directory/auth";
 pub const DIRECTORY_FEEDBACK_PATH: &str = "/v1/directory/feedback-v3/%s";
-pub const MESSAGE_PATH: &str = "/v1/messages/"; // optionally with destination appended
 pub const SENDER_ACK_MESSAGE_PATH: &str = "/v1/messages/%s/%d";
 pub const UUID_ACK_MESSAGE_PATH: &str = "/v1/messages/uuid/%s";
 pub const ATTACHMENT_PATH: &str = "/v2/attachments/form/upload";
 
-pub const PROFILE_PATH: &str = "/v1/profile/%s";
-
-pub const WEBSOCKET_PATH: &str = "/v1/websocket/";
+pub const PROFILE_PATH: &str = "/v1/profile/";
 
 pub const SENDER_CERTIFICATE_LEGACY_PATH: &str = "/v1/certificate/delivery";
 pub const SENDER_CERTIFICATE_PATH: &str =
     "/v1/certificate/delivery?includeUuid=true";
 
 pub const ATTACHMENT_DOWNLOAD_PATH: &str = "attachments/%d";
-pub const ATTACHMENT_UPLOAD_PATH: &str = "attachments/";
 
 pub const STICKER_MANIFEST_PATH: &str = "stickers/%s/manifest.proto";
 pub const STICKER_PATH: &str = "stickers/%s/full/%d";
+**/
 
 pub const KEEPALIVE_TIMEOUT_SECONDS: Duration = Duration::from_secs(55);
 
@@ -69,18 +65,85 @@ pub enum VoiceVerificationCodeResponse {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceId {
-    device_id: u32,
+    pub device_id: u32,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ConfirmCodeMessage {
+pub struct ConfirmDeviceMessage {
     #[serde(with = "serde_base64")]
     pub signaling_key: Vec<u8>,
     pub supports_sms: bool,
     pub fetches_messages: bool,
     pub registration_id: u32,
     pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmCodeMessage {
+    #[serde(with = "serde_base64")]
+    signaling_key: Vec<u8>,
+    supports_sms: bool,
+    registration_id: u32,
+    voice: bool,
+    video: bool,
+    fetches_messages: bool,
+    pin: Option<String>,
+    #[serde(with = "serde_base64")]
+    unidentified_access_key: Vec<u8>,
+    unrestricted_unidentified_access: bool,
+    discoverable_by_phone_number: bool,
+    capabilities: DeviceCapabilities,
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct DeviceCapabilities {
+    uuid: bool,
+    gv2: bool,
+    storage: bool,
+}
+
+pub struct ProfileKey(pub Vec<u8>);
+
+impl ProfileKey {
+    pub fn derive_access_key(&self) -> Result<Vec<u8>, aes_gcm::Error> {
+        let key = GenericArray::from_slice(&self.0);
+        let cipher = Aes256Gcm::new(key);
+        let nonce = GenericArray::from_slice(&[0u8; 12]);
+        let buf = [0u8; 16];
+        cipher.encrypt(nonce, &buf[..])
+    }
+}
+
+impl ConfirmCodeMessage {
+    pub fn new(
+        signaling_key: Vec<u8>,
+        registration_id: u32,
+        unidentified_access_key: Vec<u8>,
+    ) -> Self {
+        Self {
+            signaling_key,
+            supports_sms: false,
+            registration_id,
+            voice: false,
+            video: false,
+            fetches_messages: true,
+            pin: None,
+            unidentified_access_key,
+            unrestricted_unidentified_access: false,
+            discoverable_by_phone_number: true,
+            capabilities: DeviceCapabilities::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmCodeResponse {
+    pub uuid: String,
+    pub storage_capable: bool,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -112,13 +175,7 @@ pub enum ServiceError {
     MacError,
 
     #[error("Protocol error: {0}")]
-    SignalProtocolError(libsignal_protocol::InternalError),
-}
-
-impl From<libsignal_protocol::InternalError> for ServiceError {
-    fn from(pe: libsignal_protocol::InternalError) -> Self {
-        ServiceError::SignalProtocolError(pe)
-    }
+    SignalProtocolError(#[from] libsignal_protocol::Error),
 }
 
 impl ServiceError {
@@ -128,11 +185,11 @@ impl ServiceError {
             StatusCode::NO_CONTENT => Ok(()),
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
                 Err(ServiceError::Unauthorized)
-            },
+            }
             StatusCode::PAYLOAD_TOO_LARGE => {
                 // This is 413 and means rate limit exceeded for Signal.
                 Err(ServiceError::RateLimitExceeded)
-            },
+            }
             // XXX: fill in rest from PushServiceSocket
             _ => Err(ServiceError::UnhandledResponseCode {
                 http_code: code.as_u16(),
@@ -168,28 +225,64 @@ pub trait PushService {
 
     async fn request_sms_verification_code(
         &mut self,
+        phone_number: &str,
     ) -> Result<SmsVerificationCodeResponse, ServiceError> {
-        self.get(CREATE_ACCOUNT_SMS_PATH).await?;
+        match self
+            .get(&format!("/v1/accounts/sms/code/{}", phone_number))
+            .await
+        {
+            Err(ServiceError::JsonDecodeError { .. }) => Ok(()),
+            r => r,
+        }?;
         Ok(SmsVerificationCodeResponse::SmsSent)
     }
 
     async fn request_voice_verification_code(
         &mut self,
+        phone_number: &str,
     ) -> Result<VoiceVerificationCodeResponse, ServiceError> {
-        self.get(CREATE_ACCOUNT_VOICE_PATH).await?;
+        match self
+            .get(&format!("/v1/accounts/voice/code/{}", phone_number))
+            .await
+        {
+            Err(ServiceError::JsonDecodeError { .. }) => Ok(()),
+            r => r,
+        }?;
         Ok(VoiceVerificationCodeResponse::CallIssued)
+    }
+
+    async fn confirm_verification_code(
+        &mut self,
+        confirm_code: u32,
+        confirm_verification_message: ConfirmCodeMessage,
+    ) -> Result<ConfirmCodeResponse, ServiceError> {
+        self.put(
+            &format!("/v1/accounts/code/{}", confirm_code),
+            confirm_verification_message,
+        )
+        .await
     }
 
     async fn confirm_device(
         &mut self,
         confirm_code: u32,
-        confirm_code_message: &ConfirmCodeMessage,
+        confirm_code_message: ConfirmDeviceMessage,
     ) -> Result<DeviceId, ServiceError> {
         self.put(
-            &format!("{}{}", DEVICE_PATH, confirm_code),
+            &format!("/v1/devices/{}", confirm_code),
             confirm_code_message,
         )
         .await
+    }
+
+    async fn register_pre_keys(
+        &mut self,
+        pre_key_state: PreKeyState,
+    ) -> Result<(), ServiceError> {
+        match self.put("/v2/keys/", pre_key_state).await {
+            Err(ServiceError::JsonDecodeError { .. }) => Ok(()),
+            r => r,
+        }
     }
 
     async fn get_attachment_by_id(
@@ -197,7 +290,7 @@ pub trait PushService {
         id: &str,
         cdn_id: u32,
     ) -> Result<Self::ByteStream, ServiceError> {
-        let path = format!("{}{}", ATTACHMENT_UPLOAD_PATH, id);
+        let path = format!("attachments/{}", id);
         self.get_from_cdn(cdn_id, &path).await
     }
 
@@ -212,17 +305,17 @@ pub trait PushService {
                 // exist.
                 self.get_attachment_by_id(&format!("{}", id), ptr.cdn_number())
                     .await
-            },
+            }
             AttachmentIdentifier::CdnKey(key) => {
                 self.get_attachment_by_id(key, ptr.cdn_number()).await
-            },
+            }
         }
     }
 
     async fn get_messages(
         &mut self,
     ) -> Result<Vec<EnvelopeEntity>, ServiceError> {
-        let entity_list: EnvelopeEntityList = self.get(MESSAGE_PATH).await?;
+        let entity_list: EnvelopeEntityList = self.get("/v1/messages/").await?;
         Ok(entity_list.messages)
     }
 

--- a/libsignal-service/src/receiver.rs
+++ b/libsignal-service/src/receiver.rs
@@ -37,7 +37,10 @@ impl<Service: PushService> MessageReceiver<Service> {
         &mut self,
         credentials: Credentials,
     ) -> Result<MessagePipe<Service::WebSocket>, MessageReceiverError> {
-        let (ws, stream) = self.service.ws(WEBSOCKET_PATH, Some(credentials.clone())).await?;
+        let (ws, stream) = self
+            .service
+            .ws("/v1/websocket/", Some(credentials.clone()))
+            .await?;
         Ok(MessagePipe::from_socket(ws, stream, credentials))
     }
 }

--- a/libsignal-service/src/utils.rs
+++ b/libsignal-service/src/utils.rs
@@ -56,3 +56,20 @@ pub mod serde_optional_base64 {
         }
     }
 }
+
+pub mod serde_public_key {
+    use libsignal_protocol::keys::PublicKey;
+    use serde::Serializer;
+
+    pub fn serialize<S>(
+        public_key: &PublicKey,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::Error;
+        serializer
+            .serialize_str(&public_key.as_base64().map_err(S::Error::custom)?)
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/Michael-F-Bryan/libsignal-protocol-rs/pull/70

* Fix / complete registration, confirm and link functions to be able to actually receive messages with what you obtain
* Implement HTTP error handling for the websocket
* Introduce new public `SignalingKey` type, mapping to `[u8; CIPHER_KEY_SIZE + MAC_KEY_SIZE]`
* Add new `pre_key` module containing the necessary API model structs to register pre-keys
* Comment out all resource paths, as you can't use them in `format!()` anyway
* Fix register and link examples