### PR TITLE
Return missing registration_id when provisioning

### DIFF
--- a/libsignal-service-actix/src/provisioning.rs
+++ b/libsignal-service-actix/src/provisioning.rs
@@ -22,6 +22,7 @@ pub enum SecondaryDeviceProvisioning {
     NewDeviceRegistration {
         phone_number: String,
         device_id: DeviceId,
+        registration_id: u32,
         uuid: String,
         private_key: PrivateKey,
         public_key: PublicKey,
@@ -132,6 +133,7 @@ pub async fn provision_secondary_device(
                 tx.send(SecondaryDeviceProvisioning::NewDeviceRegistration {
                     phone_number,
                     device_id,
+                    registration_id,
                     uuid,
                     private_key,
                     public_key,


### PR DESCRIPTION
Pretty self explanatory, I realized it was missing when fixing my `IdentityStore` implementation.

Also remove storage of results in the link example as it's out of scope