### PR TITLE
Fix missing css/js files for docs

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -19,9 +19,10 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: doc
+          args: --all-features --no-deps
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: target/doc/libsignal_service
+          FOLDER: target/doc
           CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://github.com/Michael-F-Bryan/libsignal-service-rs/workflows/CI/badge.svg)
 [![Build Status](https://travis-ci.com/Michael-F-Bryan/libsignal-service-rs.svg?branch=master)](https://travis-ci.com/Michael-F-Bryan/libsignal-service-rs)
 
-([API Docs](https://michael-f-bryan.github.io/libsignal-service-rs))
+([API Docs](https://michael-f-bryan.github.io/libsignal-service-rs/libsignal_service))
 
 A Rust version of the [libsignal-service-java][lsj] library for communicating
 with Signal servers.


### PR DESCRIPTION
The `target/doc/libsignal_service` does not contain the necessary css and js files for a correct rendering of the documentation. This merge request fixes this.