### PR TITLE
Add default-off feature `prefer-e164` for legacy

### DIFF
--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -33,3 +33,6 @@ prost-build = "0.6"
 
 [dev-dependencies]
 anyhow = "1.0"
+
+[features]
+prefer-e164 = []

--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -302,6 +302,10 @@ pub fn get_preferred_protocol_address(
         if store_context.contains_session(&address)? {
             return Ok(address);
         }
+        if cfg!(feature = "prefer-e164") {
+            log::warn!("prefer-e164 triggered.  This is a legacy feature and shouldn't be used for new applications.");
+            return Ok(address);
+        }
     }
 
     Ok(ProtocolAddress::new(address.identifier(), device_id as i32))


### PR DESCRIPTION
Legacy applications (notably Whisperfish) are having a hard time™
migrating to UUID-identified sessions, and they would prefer keeping
E164-identified sessions for a while.

This feature flag returns a E164-identified session whenever possible.