### PR TITLE
Implement captcha support when requesting verification codes

### DIFF
--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -49,15 +49,40 @@ impl<Service: PushService> AccountManager<Service> {
         }
     }
 
+    pub async fn request_sms_verification_code_with_data(
+        &mut self,
+        phone_number: &str,
+        captcha: Option<&str>,
+        challenge: Option<&str>,
+    ) -> Result<SmsVerificationCodeResponse, ServiceError> {
+        Ok(self
+            .service
+            .request_sms_verification_code(phone_number, captcha, challenge)
+            .await?)
+    }
+
     pub async fn request_sms_verification_code(
         &mut self,
         phone_number: &str,
     ) -> Result<SmsVerificationCodeResponse, ServiceError> {
         Ok(self
             .service
-            .request_sms_verification_code(phone_number)
+            .request_sms_verification_code(phone_number, None, None)
             .await?)
     }
+
+    pub async fn request_voice_verification_code_with_data(
+        &mut self,
+        phone_number: &str,
+        captcha: Option<&str>,
+        challenge: Option<&str>,
+    ) -> Result<VoiceVerificationCodeResponse, ServiceError> {
+        Ok(self
+            .service
+            .request_voice_verification_code(phone_number, captcha, challenge)
+            .await?)
+    }
+
 
     pub async fn request_voice_verification_code(
         &mut self,
@@ -65,7 +90,7 @@ impl<Service: PushService> AccountManager<Service> {
     ) -> Result<VoiceVerificationCodeResponse, ServiceError> {
         Ok(self
             .service
-            .request_voice_verification_code(phone_number)
+            .request_voice_verification_code(phone_number, None, None)
             .await?)
     }
 

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -49,7 +49,7 @@ impl<Service: PushService> AccountManager<Service> {
         }
     }
 
-    pub async fn request_sms_verification_code_with_data(
+    pub async fn request_sms_verification_code(
         &mut self,
         phone_number: &str,
         captcha: Option<&str>,
@@ -61,17 +61,7 @@ impl<Service: PushService> AccountManager<Service> {
             .await?)
     }
 
-    pub async fn request_sms_verification_code(
-        &mut self,
-        phone_number: &str,
-    ) -> Result<SmsVerificationCodeResponse, ServiceError> {
-        Ok(self
-            .service
-            .request_sms_verification_code(phone_number, None, None)
-            .await?)
-    }
-
-    pub async fn request_voice_verification_code_with_data(
+    pub async fn request_voice_verification_code(
         &mut self,
         phone_number: &str,
         captcha: Option<&str>,
@@ -80,16 +70,6 @@ impl<Service: PushService> AccountManager<Service> {
         Ok(self
             .service
             .request_voice_verification_code(phone_number, captcha, challenge)
-            .await?)
-    }
-
-    pub async fn request_voice_verification_code(
-        &mut self,
-        phone_number: &str,
-    ) -> Result<VoiceVerificationCodeResponse, ServiceError> {
-        Ok(self
-            .service
-            .request_voice_verification_code(phone_number, None, None)
             .await?)
     }
 

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -83,7 +83,6 @@ impl<Service: PushService> AccountManager<Service> {
             .await?)
     }
 
-
     pub async fn request_voice_verification_code(
         &mut self,
         phone_number: &str,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -357,9 +357,15 @@ pub trait PushService {
         challenge: Option<&str>,
     ) -> String {
         if let Some(cl) = challenge {
-            format!("/v1/accounts/{}/code/{}?challenge={}", msg_type, phone_number, cl)
+            format!(
+                "/v1/accounts/{}/code/{}?challenge={}",
+                msg_type, phone_number, cl
+            )
         } else if let Some(cc) = captcha {
-            format!("/v1/accounts/{}/code/{}?captcha={}", msg_type, phone_number, cc)
+            format!(
+                "/v1/accounts/{}/code/{}?captcha={}",
+                msg_type, phone_number, cc
+            )
         } else {
             format!("/v1/accounts/{}/code/{}", msg_type, phone_number)
         }
@@ -372,7 +378,15 @@ pub trait PushService {
         challenge: Option<&str>,
     ) -> Result<SmsVerificationCodeResponse, ServiceError> {
         let res = match self
-            .get(Self::build_verification_code_request_url("sms", phone_number, captcha, challenge).as_ref())
+            .get(
+                Self::build_verification_code_request_url(
+                    "sms",
+                    phone_number,
+                    captcha,
+                    challenge,
+                )
+                .as_ref(),
+            )
             .await
         {
             Err(ServiceError::JsonDecodeError { .. }) => Ok(()),
@@ -380,9 +394,10 @@ pub trait PushService {
         };
         match res {
             Ok(_) => Ok(SmsVerificationCodeResponse::SmsSent),
-            Err(ServiceError::UnhandledResponseCode { http_code: 402 }) =>
-                     Ok(SmsVerificationCodeResponse::CaptchaRequired),
-            Err(e) => Err(e)
+            Err(ServiceError::UnhandledResponseCode { http_code: 402 }) => {
+                Ok(SmsVerificationCodeResponse::CaptchaRequired)
+            }
+            Err(e) => Err(e),
         }
     }
 
@@ -393,7 +408,15 @@ pub trait PushService {
         challenge: Option<&str>,
     ) -> Result<VoiceVerificationCodeResponse, ServiceError> {
         let res = match self
-            .get(Self::build_verification_code_request_url("voice", phone_number, captcha, challenge).as_ref())
+            .get(
+                Self::build_verification_code_request_url(
+                    "voice",
+                    phone_number,
+                    captcha,
+                    challenge,
+                )
+                .as_ref(),
+            )
             .await
         {
             Err(ServiceError::JsonDecodeError { .. }) => Ok(()),
@@ -401,9 +424,10 @@ pub trait PushService {
         };
         match res {
             Ok(_) => Ok(VoiceVerificationCodeResponse::CallIssued),
-            Err(ServiceError::UnhandledResponseCode { http_code: 402 }) =>
-                     Ok(VoiceVerificationCodeResponse::CaptchaRequired),
-            Err(e) => Err(e)
+            Err(ServiceError::UnhandledResponseCode { http_code: 402 }) => {
+                Ok(VoiceVerificationCodeResponse::CaptchaRequired)
+            }
+            Err(e) => Err(e),
         }
     }
 


### PR DESCRIPTION
Adds captcha and challenge support using two new methods in AccountManager  `request_sms_verification_code_with_data` and  `request_voice_verification_code_with_data` to keep the old interface working. 

