### PR TITLE
Add device ID to credentials and use it in login

### DIFF
--- a/libsignal-service-actix/examples/registering.rs
+++ b/libsignal-service-actix/examples/registering.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<(), Error> {
         e164: args.username.clone(),
         password: Some(password),
         signaling_key: Some(signaling_key),
+        device_id: None,
     };
 
     let signal_context = Context::default();

--- a/libsignal-service-actix/src/provisioning.rs
+++ b/libsignal-service-actix/src/provisioning.rs
@@ -111,6 +111,7 @@ where
                         uuid: None,
                         password: Some(password.to_string()),
                         signaling_key: Some(*signaling_key),
+                        device_id: None,
                     }),
                     USER_AGENT,
                 );

--- a/libsignal-service-actix/src/websocket.rs
+++ b/libsignal-service-actix/src/websocket.rs
@@ -138,7 +138,7 @@ impl AwcWebSocket {
 
         if let Some(credentials) = credentials {
             url.query_pairs_mut()
-                .append_pair("login", credentials.login())
+                .append_pair("login", credentials.login().as_ref())
                 .append_pair(
                     "password",
                     credentials.password.as_ref().expect("a password"),

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -4,7 +4,7 @@ use libsignal_protocol::{keys::PublicKey, Context};
 
 use crate::{
     envelope::{CIPHER_KEY_SIZE, MAC_KEY_SIZE},
-    push_service::{DEFAULT_DEVICE_ID, ServiceError},
+    push_service::{ServiceError, DEFAULT_DEVICE_ID},
     sealed_session_cipher::{CertificateValidator, SealedSessionError},
 };
 
@@ -43,14 +43,13 @@ impl Credentials {
                 uuid
             } else {
                 &self.e164
-            }.to_owned()
+            }
+            .to_owned()
         };
 
         match self.device_id {
             None | Some(DEFAULT_DEVICE_ID) => identifier,
-            Some(id) => {
-                identifier + "." + id.to_string().as_str()
-            },
+            Some(id) => identifier + "." + id.to_string().as_str(),
         }
     }
 }

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -25,6 +25,7 @@ pub struct Credentials {
     pub e164: String,
     pub password: Option<String>,
     pub signaling_key: Option<SignalingKey>,
+    pub device_id: Option<i32>,
 }
 
 impl Credentials {

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -4,7 +4,7 @@ use libsignal_protocol::{keys::PublicKey, Context};
 
 use crate::{
     envelope::{CIPHER_KEY_SIZE, MAC_KEY_SIZE},
-    push_service::ServiceError,
+    push_service::{DEFAULT_DEVICE_ID, ServiceError},
     sealed_session_cipher::{CertificateValidator, SealedSessionError},
 };
 
@@ -32,16 +32,25 @@ impl Credentials {
     /// Kind-of equivalent with `PushServiceSocket::getAuthorizationHeader`
     ///
     /// None when `self.password == None`
-    pub fn authorization(&self) -> Option<(&str, &str)> {
+    pub fn authorization(&self) -> Option<(String, &str)> {
         let identifier = self.login();
         Some((identifier, self.password.as_ref()?))
     }
 
-    pub fn login(&self) -> &str {
-        if let Some(uuid) = self.uuid.as_ref() {
-            uuid
-        } else {
-            &self.e164
+    pub fn login(&self) -> String {
+        let identifier = {
+            if let Some(uuid) = self.uuid.as_ref() {
+                uuid
+            } else {
+                &self.e164
+            }.to_owned()
+        };
+
+        match self.device_id {
+            None | Some(DEFAULT_DEVICE_ID) => identifier,
+            Some(id) => {
+                identifier + "." + id.to_string().as_str()
+            },
         }
     }
 }

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -49,7 +49,7 @@ impl Credentials {
 
         match self.device_id {
             None | Some(DEFAULT_DEVICE_ID) => identifier,
-            Some(id) => identifier + "." + id.to_string().as_str(),
+            Some(id) => format!("{}.{}", identifier, id),
         }
     }
 }


### PR DESCRIPTION
As was described in #68, currently the users of the service are not able to authorize themselves when communicating with Signal servers, when making requested on behalf of a non-primary device (e.g. after linking another device via the service). The expected authorization header should in such case be built in format `{identifier}.{device_id}:{password}`.
 
In particular, this PR:
- Adds `device_id: Option<i32>` to `Credentials`
- If `device_id` is set to non-primary device ID (i.e. other than `1`), build the `login` for authorization header in format `{identifier}.{device_id}`

Resolves #68 