### PR TITLE
Upgrade actix crates (with fixes)

### DIFF
--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2018"
 libsignal-service = { path = "../libsignal-service" }
 libsignal-protocol = { git = "https://github.com/Michael-F-Bryan/libsignal-protocol-rs" }
 
-awc = { version = "3.0.0-beta.1", features=["rustls"] }
-actix = "0.11.0-beta.1"
-actix-http = "3.0.0-beta.1"
+awc = { version = "3.0.0-beta.5", features=["rustls"] }
+actix = "0.11.1"
+actix-http = "3.0.0-beta.6"
 actix-rt = "2.0"
 mpart-async = "0.5.0"
 serde_json = "1.0"

--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -56,7 +56,7 @@ impl AwcPushService {
         {
             builder = builder.basic_auth(
                 &http_credentials.username,
-                Some(&http_credentials.password),
+                &http_credentials.password,
             );
         }
         Ok(builder)
@@ -497,8 +497,7 @@ fn get_client(cfg: &ServiceConfiguration, user_agent: &str) -> Client {
         .unwrap();
     let connector = Connector::new()
         .rustls(Arc::new(ssl_config))
-        .timeout(Duration::from_secs(10)) // https://github.com/actix/actix-web/issues/1047
-        .finish();
+        .timeout(Duration::from_secs(10)); // https://github.com/actix/actix-web/issues/1047
     let client = awc::ClientBuilder::new()
         .connector(connector)
         .header("X-Signal-Agent", user_agent)


### PR DESCRIPTION
Should fix compilation errors when you don't have the right `Cargo.lock`... for now!

`awc` > `3.0.0-beta.5`
`actix-http` > `3.0.0-beta.6`