### PR TITLE
Allow removing HTTP credentials using credentials_override

### DIFF
--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -6,7 +6,8 @@ use crate::{
     proto::{ProvisionEnvelope, ProvisionMessage, ProvisioningVersion},
     provisioning::{ProvisioningCipher, ProvisioningError},
     push_service::{
-        AccountAttributes, DeviceCapabilities, PushService, ServiceError,
+        AccountAttributes, DeviceCapabilities, HttpAuthOverride, PushService,
+        ServiceError,
     },
 };
 
@@ -16,7 +17,6 @@ use std::time::SystemTime;
 
 use libsignal_protocol::keys::PublicKey;
 use libsignal_protocol::{Context, StoreContext};
-
 use zkgroup::profiles::ProfileKey;
 
 pub struct AccountManager<Service> {
@@ -150,7 +150,11 @@ impl<Service: PushService> AccountManager<Service> {
 
         let dc: DeviceCode = self
             .service
-            .get_json(Endpoint::Service, "/v1/devices/provisioning/code", None)
+            .get_json(
+                Endpoint::Service,
+                "/v1/devices/provisioning/code",
+                HttpAuthOverride::NoOverride,
+            )
             .await?;
         Ok(dc.verification_code)
     }
@@ -174,7 +178,7 @@ impl<Service: PushService> AccountManager<Service> {
             .put_json(
                 Endpoint::Service,
                 &format!("/v1/provisioning/{}", destination),
-                None,
+                HttpAuthOverride::NoOverride,
                 &ProvisioningMessage {
                     body: base64::encode(body),
                 },

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -6,7 +6,7 @@ use zkgroup::ServerPublicParams;
 
 use crate::{
     envelope::{CIPHER_KEY_SIZE, MAC_KEY_SIZE},
-    push_service::{HttpCredentials, ServiceError, DEFAULT_DEVICE_ID},
+    push_service::{HttpAuth, ServiceError, DEFAULT_DEVICE_ID},
     sealed_session_cipher::{CertificateValidator, SealedSessionError},
 };
 
@@ -33,8 +33,8 @@ pub struct ServiceCredentials {
 }
 
 impl ServiceCredentials {
-    pub fn authorization(&self) -> Option<HttpCredentials> {
-        self.password.as_ref().map(|password| HttpCredentials {
+    pub fn authorization(&self) -> Option<HttpAuth> {
+        self.password.as_ref().map(|password| HttpAuth {
             username: self.login(),
             password: password.clone(),
         })

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -18,7 +18,10 @@ use libsignal_protocol::{
 use crate::{
     configuration::{Endpoint, ServiceConfiguration, SignalingKey},
     messagepipe::ServiceCredentials,
-    push_service::{DeviceCapabilities, DeviceId, PushService, ServiceError},
+    push_service::{
+        DeviceCapabilities, DeviceId, HttpAuthOverride, PushService,
+        ServiceError,
+    },
     utils::{serde_base64, serde_optional_base64},
 };
 
@@ -160,7 +163,7 @@ impl<P: PushService> ProvisioningManager<P> {
                     "sms", captcha, challenge,
                 )
                 .as_ref(),
-                None,
+                HttpAuthOverride::NoOverride,
             )
             .await
         {
@@ -189,7 +192,7 @@ impl<P: PushService> ProvisioningManager<P> {
                     "voice", captcha, challenge,
                 )
                 .as_ref(),
-                None,
+                HttpAuthOverride::NoOverride,
             )
             .await
         {
@@ -214,7 +217,7 @@ impl<P: PushService> ProvisioningManager<P> {
             .put_json(
                 Endpoint::Service,
                 &format!("/v1/accounts/code/{}", confirm_code),
-                None,
+                HttpAuthOverride::NoOverride,
                 confirm_verification_message,
             )
             .await
@@ -229,7 +232,7 @@ impl<P: PushService> ProvisioningManager<P> {
             .put_json(
                 Endpoint::Service,
                 &format!("/v1/devices/{}", confirm_code),
-                None,
+                HttpAuthOverride::NoOverride,
                 confirm_code_message,
             )
             .await

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -112,16 +112,6 @@ pub struct DeviceCapabilities {
 
 pub struct ProfileKey(pub [u8; 32]);
 
-impl ProfileKey {
-    pub fn derive_access_key(&self) -> Vec<u8> {
-        let key = GenericArray::from_slice(&self.0);
-        let cipher = Aes256Gcm::new(key);
-        let nonce = GenericArray::from_slice(&[0u8; 12]);
-        let buf = [0u8; 16];
-        cipher.encrypt(nonce, &buf[..]).unwrap()
-    }
-}
-
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PreKeyStatus {
@@ -144,6 +134,16 @@ pub enum HttpAuthOverride {
 impl fmt::Debug for HttpAuth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "HTTP auth with username {}", self.username)
+    }
+}
+
+impl ProfileKey {
+    pub fn derive_access_key(&self) -> Vec<u8> {
+        let key = GenericArray::from_slice(&self.0);
+        let cipher = Aes256Gcm::new(key);
+        let nonce = GenericArray::from_slice(&[0u8; 12]);
+        let buf = [0u8; 16];
+        cipher.encrypt(nonce, &buf[..]).unwrap()
     }
 }
 

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use crate::{
     configuration::{Endpoint, ServiceConfiguration, ServiceCredentials},
@@ -112,18 +112,6 @@ pub struct DeviceCapabilities {
 
 pub struct ProfileKey(pub [u8; 32]);
 
-#[derive(Debug, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct PreKeyStatus {
-    pub count: u32,
-}
-
-#[derive(Clone)]
-pub struct HttpCredentials {
-    pub username: String,
-    pub password: String,
-}
-
 impl ProfileKey {
     pub fn derive_access_key(&self) -> Vec<u8> {
         let key = GenericArray::from_slice(&self.0);
@@ -131,6 +119,31 @@ impl ProfileKey {
         let nonce = GenericArray::from_slice(&[0u8; 12]);
         let buf = [0u8; 16];
         cipher.encrypt(nonce, &buf[..]).unwrap()
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PreKeyStatus {
+    pub count: u32,
+}
+
+#[derive(Clone)]
+pub struct HttpAuth {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum HttpAuthOverride {
+    NoOverride,
+    Unidentified,
+    Identified(HttpAuth),
+}
+
+impl fmt::Debug for HttpAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HTTP auth with username {}", self.username)
     }
 }
 
@@ -283,7 +296,7 @@ pub trait PushService {
         &mut self,
         service: Endpoint,
         path: &str,
-        credentials_override: Option<HttpCredentials>,
+        credentials_override: HttpAuthOverride,
     ) -> Result<T, ServiceError>
     where
         for<'de> T: Deserialize<'de>;
@@ -300,7 +313,7 @@ pub trait PushService {
         &mut self,
         service: Endpoint,
         path: &str,
-        credentials_override: Option<HttpCredentials>,
+        credentials_override: HttpAuthOverride,
         value: S,
     ) -> Result<D, ServiceError>
     where
@@ -311,7 +324,7 @@ pub trait PushService {
         &mut self,
         service: Endpoint,
         path: &str,
-        credentials_override: Option<HttpCredentials>,
+        credentials_override: HttpAuthOverride,
     ) -> Result<T, ServiceError>
     where
         T: Default + ProtobufMessage;
@@ -365,7 +378,11 @@ pub trait PushService {
         }
 
         let devices: DeviceInfoList = self
-            .get_json(Endpoint::Service, "/v1/devices/", None)
+            .get_json(
+                Endpoint::Service,
+                "/v1/devices/",
+                HttpAuthOverride::NoOverride,
+            )
             .await?;
 
         Ok(devices.devices)
@@ -379,7 +396,12 @@ pub trait PushService {
     async fn get_pre_key_status(
         &mut self,
     ) -> Result<PreKeyStatus, ServiceError> {
-        self.get_json(Endpoint::Service, "/v2/keys/", None).await
+        self.get_json(
+            Endpoint::Service,
+            "/v2/keys/",
+            HttpAuthOverride::NoOverride,
+        )
+        .await
     }
 
     async fn register_pre_keys(
@@ -387,7 +409,12 @@ pub trait PushService {
         pre_key_state: PreKeyState,
     ) -> Result<(), ServiceError> {
         match self
-            .put_json(Endpoint::Service, "/v2/keys/", None, pre_key_state)
+            .put_json(
+                Endpoint::Service,
+                "/v2/keys/",
+                HttpAuthOverride::NoOverride,
+                pre_key_state,
+            )
             .await
         {
             Err(ServiceError::JsonDecodeError { .. }) => Ok(()),
@@ -427,8 +454,13 @@ pub trait PushService {
         messages: OutgoingPushMessages<'a>,
     ) -> Result<SendMessageResponse, ServiceError> {
         let path = format!("/v1/messages/{}", messages.destination);
-        self.put_json(Endpoint::Service, &path, None, messages)
-            .await
+        self.put_json(
+            Endpoint::Service,
+            &path,
+            HttpAuthOverride::NoOverride,
+            messages,
+        )
+        .await
     }
 
     /// Request AttachmentV2UploadAttributes
@@ -437,8 +469,12 @@ pub trait PushService {
     async fn get_attachment_v2_upload_attributes(
         &mut self,
     ) -> Result<AttachmentV2UploadAttributes, ServiceError> {
-        self.get_json(Endpoint::Service, "/v2/attachments/form/upload", None)
-            .await
+        self.get_json(
+            Endpoint::Service,
+            "/v2/attachments/form/upload",
+            HttpAuthOverride::NoOverride,
+        )
+        .await
     }
 
     /// Upload attachment to CDN
@@ -475,15 +511,23 @@ pub trait PushService {
         &mut self,
     ) -> Result<Vec<EnvelopeEntity>, ServiceError> {
         let entity_list: EnvelopeEntityList = self
-            .get_json(Endpoint::Service, "/v1/messages/", None)
+            .get_json(
+                Endpoint::Service,
+                "/v1/messages/",
+                HttpAuthOverride::NoOverride,
+            )
             .await?;
         Ok(entity_list.messages)
     }
 
     /// Method used to check our own UUID
     async fn whoami(&mut self) -> Result<WhoAmIResponse, ServiceError> {
-        self.get_json(Endpoint::Service, "/v1/accounts/whoami", None)
-            .await
+        self.get_json(
+            Endpoint::Service,
+            "/v1/accounts/whoami",
+            HttpAuthOverride::NoOverride,
+        )
+        .await
     }
 
     async fn get_pre_key(
@@ -503,8 +547,9 @@ pub trait PushService {
             format!("/v2/keys/{}/{}", destination.identifier(), device_id)
         };
 
-        let mut pre_key_response: PreKeyResponse =
-            self.get_json(Endpoint::Service, &path, None).await?;
+        let mut pre_key_response: PreKeyResponse = self
+            .get_json(Endpoint::Service, &path, HttpAuthOverride::NoOverride)
+            .await?;
         assert!(!pre_key_response.devices.is_empty());
 
         let device = pre_key_response.devices.remove(0);
@@ -554,8 +599,9 @@ pub trait PushService {
                 relay
             ),
         };
-        let pre_key_response: PreKeyResponse =
-            self.get_json(Endpoint::Service, &path, None).await?;
+        let pre_key_response: PreKeyResponse = self
+            .get_json(Endpoint::Service, &path, HttpAuthOverride::NoOverride)
+            .await?;
         let mut pre_keys = vec![];
         for device in pre_key_response.devices {
             let mut bundle = PreKeyBundle::builder()
@@ -588,10 +634,14 @@ pub trait PushService {
 
     async fn get_group(
         &mut self,
-        credentials: HttpCredentials,
+        credentials: HttpAuth,
     ) -> Result<crate::proto::Group, ServiceError> {
-        self.get_protobuf(Endpoint::Storage, "/v1/groups/", Some(credentials))
-            .await
+        self.get_protobuf(
+            Endpoint::Storage,
+            "/v1/groups/",
+            HttpAuthOverride::Identified(credentials),
+        )
+        .await
     }
 
     async fn set_account_attributes(
@@ -607,7 +657,7 @@ pub trait PushService {
             .put_json(
                 Endpoint::Service,
                 "/v1/accounts/attributes/",
-                None,
+                HttpAuthOverride::NoOverride,
                 attributes,
             )
             .await
@@ -666,7 +716,12 @@ pub trait PushService {
 
         // XXX this should  be a struct; cfr ProfileAvatarUploadAttributes
         let response: Result<String, _> = self
-            .put_json(Endpoint::Service, "/v1/profile", None, command)
+            .put_json(
+                Endpoint::Service,
+                "/v1/profile",
+                HttpAuthOverride::NoOverride,
+                command,
+            )
             .await;
         match (response, avatar) {
             (Ok(_url), Some(_avatar)) => {


### PR DESCRIPTION
Using an enum like this avoids us to have types like `Option<Option<HttpCredentials>>` that are hard to parse by humans.

This is also helpful for structs that perform authenticated and non-authenticated requests, which can now be a hidden implementation detail.