### PR TITLE
Reuse http client.

### DIFF
--- a/libsignal-service-actix/examples/link.rs
+++ b/libsignal-service-actix/examples/link.rs
@@ -42,8 +42,11 @@ async fn main() -> Result<(), Error> {
         base64::encode(&signaling_key.to_vec())
     );
 
+    let push_service =
+        AwcPushService::new(args.servers, None, USER_AGENT.into());
+
     let mut provision_manager: LinkingManager<AwcPushService> =
-        LinkingManager::new(args.servers, USER_AGENT.into(), password);
+        LinkingManager::new(push_service, password);
 
     let (tx, mut rx) = channel(1);
 

--- a/libsignal-service-actix/examples/registering.rs
+++ b/libsignal-service-actix/examples/registering.rs
@@ -33,10 +33,11 @@ async fn main() -> Result<(), Error> {
     // Only used with MessageSender and MessageReceiver
     // let password = args.get_password()?;
 
+    let mut push_service =
+        AwcPushService::new(args.servers, None, USER_AGENT.into());
     let mut provision_manager: ProvisioningManager<AwcPushService> =
         ProvisioningManager::new(
-            args.servers,
-            USER_AGENT.into(),
+            &mut push_service,
             args.username,
             args.password.unwrap(),
         );

--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -26,6 +26,20 @@ pub struct AwcPushService {
 }
 
 impl AwcPushService {
+    pub fn new(
+        cfg: impl Into<ServiceConfiguration>,
+        credentials: Option<ServiceCredentials>,
+        user_agent: String,
+    ) -> Self {
+        let cfg = cfg.into();
+        let client = get_client(&cfg, user_agent);
+        Self {
+            cfg,
+            credentials: credentials.and_then(|c| c.authorization()),
+            client,
+        }
+    }
+
     fn request(
         &self,
         method: Method,
@@ -112,20 +126,6 @@ impl PushService for AwcPushService {
     // This is in principle known at compile time, but long to write out.
     type ByteStream = Box<dyn futures::io::AsyncRead + Unpin>;
     type WebSocket = AwcWebSocket;
-
-    fn new(
-        cfg: impl Into<ServiceConfiguration>,
-        credentials: Option<ServiceCredentials>,
-        user_agent: String,
-    ) -> Self {
-        let cfg = cfg.into();
-        let client = get_client(&cfg, user_agent);
-        Self {
-            cfg,
-            credentials: credentials.and_then(|c| c.authorization()),
-            client,
-        }
-    }
 
     async fn get_json<T>(
         &mut self,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -315,7 +315,7 @@ pub enum ServiceError {
 }
 
 #[async_trait::async_trait(?Send)]
-pub trait PushService: Clone {
+pub trait PushService {
     type WebSocket: WebSocketService;
     type ByteStream: futures::io::AsyncRead + Unpin;
 

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1,7 +1,7 @@
 use std::{fmt, time::Duration};
 
 use crate::{
-    configuration::{Endpoint, ServiceConfiguration, ServiceCredentials},
+    configuration::{Endpoint, ServiceCredentials},
     envelope::*,
     groups_v2::GroupDecryptionError,
     messagepipe::WebSocketService,
@@ -315,15 +315,9 @@ pub enum ServiceError {
 }
 
 #[async_trait::async_trait(?Send)]
-pub trait PushService {
+pub trait PushService: Clone {
     type WebSocket: WebSocketService;
     type ByteStream: futures::io::AsyncRead + Unpin;
-
-    fn new(
-        cfg: impl Into<ServiceConfiguration>,
-        credentials: Option<ServiceCredentials>,
-        user_agent: String,
-    ) -> Self;
 
     async fn get_json<T>(
         &mut self,


### PR DESCRIPTION
The push service is provided to managers from outside, instead of
being created inside. This makes it possible to reuse the same
push service (http client) between managers.